### PR TITLE
Update heti.scss

### DIFF
--- a/lib/heti.scss
+++ b/lib/heti.scss
@@ -34,6 +34,8 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   hyphens: auto;
+  -ms-hyphens: auto;
+  -webkit-hyphens: auto
 
   // 自动在中西文间加 1/4 空格（暂无浏览器支持）
   //text-spacing: ideograph-alpha;


### PR DESCRIPTION
hyphens' is not supported by Edge, Safari, Safari on iOS. Add '-ms-hyphens' to support Edge 12+. Add '-webkit-hyphens' to support Safari 5.1+, Safari on iOS 4.2+
