### PR TITLE
fix: fix `<em>` styling

### DIFF
--- a/_site/heti.css
+++ b/_site/heti.css
@@ -769,11 +769,14 @@
 .heti--annotation em {
   -webkit-text-emphasis: filled circle;
   -webkit-text-emphasis-position: under;
+  text-emphasis: filled circle;
+  text-emphasis-position: under right;
   font-weight: 400;
 }
 
 .heti--annotation em:not(:lang(zh)):not(:lang(ja)):not(:lang(kr)), .heti--annotation em:not(:lang(zh)) {
   -webkit-text-emphasis: none;
+  text-emphasis: none;
 }
 
 .heti--annotation .heti-meta {
@@ -883,10 +886,13 @@
 .heti .heti-em {
   -webkit-text-emphasis: filled circle;
   -webkit-text-emphasis-position: under;
+  text-emphasis: filled circle;
+  text-emphasis-position: under right;
 }
 
 .heti .heti-em:not(:lang(zh)):not(:lang(ja)):not(:lang(kr)), .heti .heti-em:not(:lang(zh)) {
   -webkit-text-emphasis: none;
+  text-emphasis: none;
 }
 
 .heti .heti-ruby--inline {

--- a/lib/helpers/_inline.scss
+++ b/lib/helpers/_inline.scss
@@ -13,9 +13,12 @@
   #{$root-selector}-em {
     -webkit-text-emphasis: filled circle;
     -webkit-text-emphasis-position: under;
+    text-emphasis: filled circle;
+    text-emphasis-position: under right;
 
     @include non-cjk-block {
       -webkit-text-emphasis: none;
+      text-emphasis: none;
     }
   }
 

--- a/lib/modifiers/annotation.scss
+++ b/lib/modifiers/annotation.scss
@@ -16,10 +16,13 @@
     em {
       -webkit-text-emphasis: filled circle;
       -webkit-text-emphasis-position: under;
+      text-emphasis: filled circle;
+      text-emphasis-position: under right;
       font-weight: $font-weight-normal;
 
       @include non-cjk-block {
         -webkit-text-emphasis: none;
+        text-emphasis: none;
       }
     }
 


### PR DESCRIPTION
This PR fixes `<em>` styling in some modern browsers.

Some links:
- <https://caniuse.com/text-emphasis>
- <https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis>
- <https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position>