### PR TITLE
fix: 楷体显示为宋体 等

### DIFF
--- a/_site/heti.css
+++ b/_site/heti.css
@@ -52,19 +52,19 @@
 
 @font-face {
   font-family: "Heti Kai";
-  src: local("Kaiti SC Regular"), local("Kaiti TC Regular"), local("BiauKai");
+  src: local("Kaiti SC Regular"), local("Kaiti TC Regular"), local("STKaiti"), local("Kaiti"), local("BiauKai");
 }
 
 @font-face {
   font-family: "Heti Kai";
   font-weight: 600;
-  src: local("Kaiti SC Bold"), local("Kaiti TC Bold");
+  src: local("Kaiti SC Bold"), local("Kaiti TC Bold"), local("STKaiti"), local("Kaiti");
 }
 
 @font-face {
   font-family: "Heti Kai Black";
   font-weight: 800;
-  src: local("Kaiti SC Black"), local("Kaiti TC Black");
+  src: local("Kaiti SC Black"), local("Kaiti TC Black"), local("STKaiti"), local("Kaiti");
 }
 
 .heti {

--- a/_site/heti.css
+++ b/_site/heti.css
@@ -6,25 +6,135 @@
  */
 @font-face {
   font-family: "Heti Hei";
-  src: local("PingFang SC Regular"), local("PingFang TC Regular"), local("Hiragino Sans GB W3"), local("Heiti SC Regular"), local("Heiti TC Regular"), local("Microsoft YaHei"), local("Microsoft Jhenghei"), local("Source Han Sans CN Regular"), local("Source Han Sans HK Regular"), local("Source Han Sans TW Regular"), local("Source Han Sans JP Regular"), local("Source Han Sans KR Regular"), local("Noto Sans CJK SC Regular"), local("Noto Sans CJK TC Regular"), local("Noto Sans CJK JP Regular"), local("Noto Sans CJK KR Regular"), local("WenQuanYi Micro Hei"), local("Droid Sans Fallback");
+  src: "Heti Hei SC", "Heti Hei TC", "Heti Hei JP", "Heti Hei KR";
+}
+
+@font-face {
+  font-family: "Heti Hei SC";
+  src: local("PingFang SC Regular"), local("Heiti SC Regular"), local("Microsoft YaHei"), local("Source Han Sans CN Regular"), local("Noto Sans CJK SC Regular"), local("WenQuanYi Micro Hei"), local("Droid Sans Fallback");
+}
+
+@font-face {
+  font-family: "Heti Hei TC";
+  src: local("PingFang TC Regular"), local("Heiti TC Regular"), local("Microsoft Jhenghei"), local("Source Han Sans HK Regular"), local("Source Han Sans TW Regular"), local("Noto Sans CJK TC Regular"), local("WenQuanYi Micro Hei"), local("Droid Sans Fallback");
+}
+
+@font-face {
+  font-family: "Heti Hei JP";
+  src: local("Hiragino Sans GB W3"), local("Source Han Sans JP Regular"), local("Noto Sans CJK JP Regular"), local("Droid Sans Fallback");
+}
+
+@font-face {
+  font-family: "Heti Hei KR";
+  src: local("Source Han Sans KR Regular"), local("Noto Sans CJK KR Regular"), local("Droid Sans Fallback");
 }
 
 @font-face {
   font-family: "Heti Hei";
   font-weight: 200;
-  src: local("PingFang SC Light"), local("PingFang TC Light"), local("Heiti SC Light"), local("Heiti TC Light"), local("Microsoft YaHei Light"), local("Microsoft Jhenghei Light"), local("Source Han Sans CN Light"), local("Source Han Sans HK Light"), local("Source Han Sans TW Light"), local("Source Han Sans JP Light"), local("Source Han Sans KR Light"), local("Noto Sans CJK SC Light"), local("Noto Sans CJK TC Light"), local("Noto Sans CJK JP Light"), local("Noto Sans CJK KR Light");
+  src: "Heti Hei SC Light", "Heti Hei TC Light", "Heti Hei JP Light", "Heti Hei KR Light";
+}
+
+@font-face {
+  font-family: "Heti Hei SC Light";
+  font-weight: 200;
+  src: local("PingFang SC Light"), local("Heiti SC Light"), "Heti Hei SC Light Fallback", local("Source Han Sans CN Light"), local("Noto Sans CJK SC Light");
+}
+
+@font-face {
+  font-family: "Heti Hei TC Light";
+  font-weight: 200;
+  src: local("PingFang TC Light"), local("Heiti TC Light"), local("Microsoft Jhenghei Light"), local("Source Han Sans HK Light"), local("Source Han Sans TW Light"), local("Noto Sans CJK TC Light");
+}
+
+@font-face {
+  font-family: "Heti Hei JP Light";
+  font-weight: 200;
+  src: local("Source Han Sans JP Light"), local("Noto Sans CJK JP Light");
+}
+
+@font-face {
+  font-family: "Heti Hei KR Light";
+  font-weight: 200;
+  src: local("Source Han Sans KR Light"), local("Noto Sans CJK KR Light");
+}
+
+@font-face {
+  font-family: "Heti Hei SC Light Fallback";
+  font-weight: 200;
+  src: local("Microsoft YaHei"), local("Droid Sans Fallback");
 }
 
 @font-face {
   font-family: "Heti Hei";
   font-weight: 600;
-  src: local("PingFang SC Medium"), local("Hiragino Sans GB W6"), local("PingFang TC Medium"), local("Heiti SC Medium"), local("Heiti TC Medium"), local("Microsoft YaHei Bold"), local("Microsoft Jhenghei Bold"), local("Source Han Sans CN Bold"), local("Source Han Sans HK Bold"), local("Source Han Sans TW Bold"), local("Source Han Sans JP Bold"), local("Source Han Sans KR Bold"), local("Noto Sans CJK SC Bold"), local("Noto Sans CJK TC Bold"), local("Noto Sans CJK JP Bold"), local("Noto Sans CJK KR Bold");
+  src: "Heti Hei SC Bold", "Heti Hei TC Bold", "Heti Hei JP Bold", "Heti Hei KR Bold";
+}
+
+@font-face {
+  font-family: "Heti Hei SC Bold";
+  font-weight: 600;
+  src: local("PingFang SC Medium"), local("Heiti SC Medium"), "Heti Hei SC Bold Fallback", local("Source Han Sans CN Bold"), local("Noto Sans CJK SC Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei TC Bold";
+  font-weight: 600;
+  src: local("PingFang TC Medium"), local("Heiti TC Medium"), local("Microsoft Jhenghei Bold"), local("Source Han Sans HK Bold"), local("Source Han Sans TW Bold"), local("Noto Sans CJK TC Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei JP Bold";
+  font-weight: 600;
+  src: local("Hiragino Sans GB W6"), local("Source Han Sans JP Bold"), local("Noto Sans CJK JP Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei KR Bold";
+  font-weight: 600;
+  src: local("Source Han Sans KR Bold"), local("Noto Sans CJK KR Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei SC Bold Fallback";
+  font-weight: 600;
+  src: local("Microsoft YaHei"), local("Droid Sans Fallback");
 }
 
 @font-face {
   font-family: "Heti Hei Black";
   font-weight: 800;
-  src: local("Lantinghei SC Heavy"), local("Lantinghei TC Heavy"), local("PingFang SC Semibold"), local("PingFang TC Semibold"), local("Hiragino Sans GB W6"), local("Heiti SC Medium"), local("Heiti TC Medium"), local("Microsoft YaHei Bold"), local("Microsoft Jhenghei Bold"), local("Source Han Sans CN Heavy"), local("Source Han Sans HK Heavy"), local("Source Han Sans TW Heavy"), local("Source Han Sans JP Heavy"), local("Source Han Sans KR Heavy"), local("Noto Sans CJK SC Heavy"), local("Noto Sans CJK TC Heavy"), local("Noto Sans CJK JP Heavy"), local("Noto Sans CJK KR Heavy"), local("Droid Sans Fallback");
+  src: "Heti Hei SC Black", "Heti Hei TC Black", "Heti Hei JP Black", "Heti Hei KR Black";
+}
+
+@font-face {
+  font-family: "Heti Hei SC Black";
+  font-weight: 800;
+  src: local("Lantinghei SC Heavy"), local("PingFang SC Semibold"), local("Heiti SC Medium"), "Heti Hei SC Black Fallback", local("Source Han Sans CN Heavy"), local("Noto Sans CJK SC Heavy");
+}
+
+@font-face {
+  font-family: "Heti Hei TC Black";
+  font-weight: 800;
+  src: local("Lantinghei TC Heavy"), local("PingFang TC Semibold"), local("Heiti TC Medium"), local("Microsoft Jhenghei Bold"), local("Source Han Sans HK Heavy"), local("Source Han Sans TW Heavy"), local("Noto Sans CJK TC Heavy");
+}
+
+@font-face {
+  font-family: "Heti Hei JP Black";
+  font-weight: 800;
+  src: local("Hiragino Sans GB W6"), local("Source Han Sans JP Heavy"), local("Noto Sans CJK JP Heavy");
+}
+
+@font-face {
+  font-family: "Heti Hei KR Black";
+  font-weight: 800;
+  src: local("Source Han Sans KR Heavy"), local("Noto Sans CJK KR Heavy");
+}
+
+font-face {
+  font-family: "Heti Hei SC Black Fallback";
+  font-weight: 800;
+  src: local("Microsoft YaHei"), local("Droid Sans Fallback");
 }
 
 @font-face {
@@ -35,13 +145,25 @@
 @font-face {
   font-family: "Heti Song";
   font-weight: 200;
-  src: local("Songti SC Light"), local("Songti TC Light"), local("STSong"), local("SimSun");
+  src: local("Songti SC Light"), local("Songti TC Light"), "Heti Song Light Fallback";
+}
+
+@font-face {
+  font-family: "Heti Song Light Fallback";
+  font-weight: 200;
+  src: local("SimSun");
 }
 
 @font-face {
   font-family: "Heti Song";
   font-weight: 600;
-  src: local("Songti SC Bold"), local("Songti TC Bold"), local("SimSun");
+  src: local("Songti SC Bold"), local("Songti TC Bold"), "Heti Song Bold Fallback";
+}
+
+@font-face {
+  font-family: "Heti Song Bold Fallback";
+  font-weight: 600;
+  src: local("SimSun");
 }
 
 @font-face {
@@ -58,7 +180,13 @@
 @font-face {
   font-family: "Heti Kai";
   font-weight: 600;
-  src: local("Kaiti SC Bold"), local("Kaiti TC Bold"), local("STKaiti"), local("Kaiti");
+  src: local("Kaiti SC Bold"), local("Kaiti TC Bold");
+}
+
+@font-face {
+  font-family: "Heti Kai Bold Fallback";
+  font-weight: 600;
+  src: local("STKaiti"), local("Kaiti") local("BiauKai");
 }
 
 @font-face {

--- a/lib/fonts/_hei.scss
+++ b/lib/fonts/_hei.scss
@@ -1,27 +1,55 @@
-// Author: Sivan [sun.sivan@gmail.com]
+// Author: Sivan [sun.sivan@gmail.com], Pan RZ [c141028@gmail.com]
 // Description: define font-face Heti Hei.
 
 // 标准 Regular
 @font-face {
   font-family: "Heti Hei";
   src:
+    "Heti Hei SC",
+    "Heti Hei TC",
+    "Heti Hei JP",
+    "Heti Hei KR";
+}
+
+@font-face {
+  font-family: "Heti Hei SC";
+  src:
     local("PingFang SC Regular"),
-    local("PingFang TC Regular"),
-    local("Hiragino Sans GB W3"),
     local("Heiti SC Regular"),
-    local("Heiti TC Regular"),
     local("Microsoft YaHei"),
-    local("Microsoft Jhenghei"),
     local("Source Han Sans CN Regular"),
+    local("Noto Sans CJK SC Regular"),
+    local("WenQuanYi Micro Hei"),
+    local("Droid Sans Fallback");
+}
+
+@font-face {
+  font-family: "Heti Hei TC";
+  src:
+    local("PingFang TC Regular"),
+    local("Heiti TC Regular"),
+    local("Microsoft Jhenghei"),
     local("Source Han Sans HK Regular"),
     local("Source Han Sans TW Regular"),
-    local("Source Han Sans JP Regular"),
-    local("Source Han Sans KR Regular"),
-    local("Noto Sans CJK SC Regular"),
     local("Noto Sans CJK TC Regular"),
-    local("Noto Sans CJK JP Regular"),
-    local("Noto Sans CJK KR Regular"),
     local("WenQuanYi Micro Hei"),
+    local("Droid Sans Fallback");
+}
+
+@font-face {
+  font-family: "Heti Hei JP";
+  src:
+    local("Hiragino Sans GB W3"),
+    local("Source Han Sans JP Regular"),
+    local("Noto Sans CJK JP Regular"),
+    local("Droid Sans Fallback");
+}
+
+@font-face {
+  font-family: "Heti Hei KR";
+  src:
+    local("Source Han Sans KR Regular"),
+    local("Noto Sans CJK KR Regular"),
     local("Droid Sans Fallback");
 }
 
@@ -30,21 +58,57 @@
   font-family: "Heti Hei";
   font-weight: 200;
   src:
+    "Heti Hei SC Light",
+    "Heti Hei TC Light",
+    "Heti Hei JP Light",
+    "Heti Hei KR Light";
+}
+
+@font-face {
+  font-family: "Heti Hei SC Light";
+  font-weight: 200;
+  src:
     local("PingFang SC Light"),
-    local("PingFang TC Light"),
     local("Heiti SC Light"),
-    local("Heiti TC Light"),
-    local("Microsoft YaHei Light"),
-    local("Microsoft Jhenghei Light"),
+    "Heti Hei SC Light Fallback",
     local("Source Han Sans CN Light"),
+    local("Noto Sans CJK SC Light");
+}
+
+@font-face {
+  font-family: "Heti Hei TC Light";
+  font-weight: 200;
+  src:
+    local("PingFang TC Light"),
+    local("Heiti TC Light"),
+    local("Microsoft Jhenghei Light"),
     local("Source Han Sans HK Light"),
     local("Source Han Sans TW Light"),
+    local("Noto Sans CJK TC Light");
+}
+
+@font-face {
+  font-family: "Heti Hei JP Light";
+  font-weight: 200;
+  src:
     local("Source Han Sans JP Light"),
+    local("Noto Sans CJK JP Light");
+}
+
+@font-face {
+  font-family: "Heti Hei KR Light";
+  font-weight: 200;
+  src:
     local("Source Han Sans KR Light"),
-    local("Noto Sans CJK SC Light"),
-    local("Noto Sans CJK TC Light"),
-    local("Noto Sans CJK JP Light"),
     local("Noto Sans CJK KR Light");
+}
+
+@font-face {
+  font-family: "Heti Hei SC Light Fallback";
+  font-weight: 200;
+  src:
+    local("Microsoft YaHei"),
+    local("Droid Sans Fallback");
 }
 
 // 粗体 Bold
@@ -52,22 +116,58 @@
   font-family: "Heti Hei";
   font-weight: 600;
   src:
+    "Heti Hei SC Bold",
+    "Heti Hei TC Bold",
+    "Heti Hei JP Bold",
+    "Heti Hei KR Bold";
+}
+
+@font-face {
+  font-family: "Heti Hei SC Bold";
+  font-weight: 600;
+  src:
     local("PingFang SC Medium"),
-    local("Hiragino Sans GB W6"),
-    local("PingFang TC Medium"),
     local("Heiti SC Medium"),
-    local("Heiti TC Medium"),
-    local("Microsoft YaHei Bold"),
-    local("Microsoft Jhenghei Bold"),
+    "Heti Hei SC Bold Fallback",
     local("Source Han Sans CN Bold"),
+    local("Noto Sans CJK SC Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei TC Bold";
+  font-weight: 600;
+  src:
+    local("PingFang TC Medium"),
+    local("Heiti TC Medium"),
+    local("Microsoft Jhenghei Bold"),
     local("Source Han Sans HK Bold"),
     local("Source Han Sans TW Bold"),
+    local("Noto Sans CJK TC Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei JP Bold";
+  font-weight: 600;
+  src:
+    local("Hiragino Sans GB W6"),
     local("Source Han Sans JP Bold"),
+    local("Noto Sans CJK JP Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei KR Bold";
+  font-weight: 600;
+  src:
     local("Source Han Sans KR Bold"),
-    local("Noto Sans CJK SC Bold"),
-    local("Noto Sans CJK TC Bold"),
-    local("Noto Sans CJK JP Bold"),
     local("Noto Sans CJK KR Bold");
+}
+
+@font-face {
+  font-family: "Heti Hei SC Bold Fallback";
+  font-weight: 600;
+  src:
+    local("Microsoft YaHei"),
+    local("Droid Sans Fallback");
 }
 
 // 黑体 Black
@@ -75,23 +175,58 @@
   font-family: "Heti Hei Black";
   font-weight: 800;
   src:
+    "Heti Hei SC Black",
+    "Heti Hei TC Black",
+    "Heti Hei JP Black",
+    "Heti Hei KR Black";
+}
+
+@font-face {
+  font-family: "Heti Hei SC Black";
+  font-weight: 800;
+  src:
     local("Lantinghei SC Heavy"),
-    local("Lantinghei TC Heavy"),
     local("PingFang SC Semibold"),
-    local("PingFang TC Semibold"),
-    local("Hiragino Sans GB W6"),
     local("Heiti SC Medium"),
-    local("Heiti TC Medium"),
-    local("Microsoft YaHei Bold"),
-    local("Microsoft Jhenghei Bold"),
+    "Heti Hei SC Black Fallback",
     local("Source Han Sans CN Heavy"),
+    local("Noto Sans CJK SC Heavy");
+}
+
+@font-face {
+  font-family: "Heti Hei TC Black";
+  font-weight: 800;
+  src:
+    local("Lantinghei TC Heavy"),
+    local("PingFang TC Semibold"),
+    local("Heiti TC Medium"),
+    local("Microsoft Jhenghei Bold"),
     local("Source Han Sans HK Heavy"),
     local("Source Han Sans TW Heavy"),
+    local("Noto Sans CJK TC Heavy");
+}
+
+@font-face {
+  font-family: "Heti Hei JP Black";
+  font-weight: 800;
+  src:
+    local("Hiragino Sans GB W6"),
     local("Source Han Sans JP Heavy"),
+    local("Noto Sans CJK JP Heavy");
+}
+
+@font-face {
+  font-family: "Heti Hei KR Black";
+  font-weight: 800;
+  src:
     local("Source Han Sans KR Heavy"),
-    local("Noto Sans CJK SC Heavy"),
-    local("Noto Sans CJK TC Heavy"),
-    local("Noto Sans CJK JP Heavy"),
-    local("Noto Sans CJK KR Heavy"),
+    local("Noto Sans CJK KR Heavy");
+}
+
+font-face {
+  font-family: "Heti Hei SC Black Fallback";
+  font-weight: 800;
+  src:
+    local("Microsoft YaHei"),
     local("Droid Sans Fallback");
 }

--- a/lib/fonts/_kai.scss
+++ b/lib/fonts/_kai.scss
@@ -7,6 +7,8 @@
   src:
     local("Kaiti SC Regular"),
     local("Kaiti TC Regular"),
+    local("STKaiti"),
+    local("Kaiti"),
     local("BiauKai");
 }
 
@@ -16,7 +18,9 @@
   font-weight: 600;
   src:
     local("Kaiti SC Bold"),
-    local("Kaiti TC Bold");
+    local("Kaiti TC Bold"),
+    local("STKaiti"),
+    local("Kaiti");
 }
 
 // 黑体 Black
@@ -25,5 +29,7 @@
   font-weight: 800;
   src:
     local("Kaiti SC Black"),
-    local("Kaiti TC Black");
+    local("Kaiti TC Black"),
+    local("STKaiti"),
+    local("Kaiti");
 }

--- a/lib/fonts/_kai.scss
+++ b/lib/fonts/_kai.scss
@@ -1,4 +1,4 @@
-// Author: Sivan [sun.sivan@gmail.com]
+// Author: Sivan [sun.sivan@gmail.com], Pan RZ [c141028@gmail.com]
 // Description: define font-face Heti Kai.
 
 // 标准 Regular
@@ -18,9 +18,16 @@
   font-weight: 600;
   src:
     local("Kaiti SC Bold"),
-    local("Kaiti TC Bold"),
+    local("Kaiti TC Bold");
+}
+
+@font-face {
+  font-family: "Heti Kai Bold Fallback";
+  font-weight: 600;
+  src:
     local("STKaiti"),
-    local("Kaiti");
+    local("Kaiti")
+    local("BiauKai");
 }
 
 // 黑体 Black

--- a/lib/fonts/_song.scss
+++ b/lib/fonts/_song.scss
@@ -1,4 +1,4 @@
-// Author: Sivan [sun.sivan@gmail.com]
+// Author: Sivan [sun.sivan@gmail.com], Pan RZ [c141028@gmail.com]
 // Description: define font-face Heti Song.
 
 // 标准 Regular
@@ -17,7 +17,13 @@
   src:
     local("Songti SC Light"),
     local("Songti TC Light"),
-    local("STSong"),
+    "Heti Song Light Fallback";
+}
+
+@font-face {
+  font-family: "Heti Song Light Fallback";
+  font-weight: 200;
+  src:
     local("SimSun");
 }
 
@@ -28,6 +34,13 @@
   src:
     local("Songti SC Bold"),
     local("Songti TC Bold"),
+    "Heti Song Bold Fallback";
+}
+
+@font-face {
+  font-family: "Heti Song Bold Fallback";
+  font-weight: 600;
+  src:
     local("SimSun");
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "heti",
-  "version": "0.8.2",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
- 修复了楷体显示为宋体的问题，closes #72。引入了 `STKaiti` `Kaiti` 两个字体。
- 修复了字形回退问题（见下图「角」字和「情形」二字）。`@font-face` 中 `src` 工作原理为随机选择，可能导致字形回退。因此区分 SC/TC/JP/KR 字体，确保即使随机也只是在特定字体族中随机，不会发生回退。
- 修复了宋体加粗不显示的问题，closes #73。同名 font-face 的相同 `src`，匹配不同字重时需要额外指定一次 `font-weight`。
- closes #69，closes #65。

对比图如下：

![image](https://user-images.githubusercontent.com/24671280/151040391-26bcb09e-dc55-4cb9-8055-866ad647a512.png)
