### PR TITLE
fix: vertical support for `<hr>` (fix #126)

### DIFF
--- a/lib/_base.scss
+++ b/lib/_base.scss
@@ -49,8 +49,8 @@
   }
 
   hr {
-    width: 30%;
-    height: 1px;
+    inline-size: 30%;
+    block-size: 1px;
     margin-block-start: $std-block-unit * 2;
     margin-block-end: $std-block-unit * 2 - 1px;
     margin-inline-start: auto;


### PR DESCRIPTION
|   | img |
|-----|-----|
| pre | ![](https://github.com/user-attachments/assets/a2b087a7-a89f-4612-bc41-dd77430af359) |
| post | ![](https://github.com/user-attachments/assets/80b7ccff-2cab-45c6-85ee-e4b6ec7323ff) |


(`<hr>` in the pictures above are added manually.)